### PR TITLE
Add nv_color_mask addon to help color-impaired people

### DIFF
--- a/addons/nv_color_mask/$PBOPREFIX$
+++ b/addons/nv_color_mask/$PBOPREFIX$
@@ -1,0 +1,1 @@
+cnto\additions\nv_color_mask

--- a/addons/nv_color_mask/$PREFIX$
+++ b/addons/nv_color_mask/$PREFIX$
@@ -1,0 +1,1 @@
+cnto\additions\nv_color_mask

--- a/addons/nv_color_mask/config.cpp
+++ b/addons/nv_color_mask/config.cpp
@@ -1,0 +1,56 @@
+/*
+ * make NVGs full-screen and ACE-like in visual appearance
+ */
+class CfgPatches {
+    class cnto_nv_color_mask {
+        units[] = {};
+        weapons[] = {};
+        requiredAddons[] = {
+            "cba_events",
+            "cba_xeh",
+            /*
+             * this is not strictly needed, but since all masks will be
+             * user-configured relative to ACE's green NVGs, it makes
+             * sense to require ACE Nightvision
+             */
+            "ace_nightvision"
+        };
+    };
+};
+
+class CfgFunctions {
+    class cnto_nv_color_mask {
+        class all {
+            file = "\cnto\additions\nv_color_mask";
+            class init;
+            class setupEH;
+            class applyMask;
+        };
+    };
+};
+
+class Extended_PreInit_EventHandlers {
+    class cnto_nv_color_mask {
+        init = "[] call cnto_nv_color_mask_fnc_init";
+    };
+};
+
+#define DISPLAY_DISABLE(rscname) \
+    class rscname { \
+        cnto_nv_color_mask = "[false] call cnto_nv_color_mask_fnc_applyMask"; \
+    }
+#define DISPLAY_RESTORE(rscname) \
+    class rscname { \
+        cnto_nv_color_mask = "[] call cnto_nv_color_mask_fnc_applyMask"; \
+    }
+
+class Extended_DisplayLoad_EventHandlers {
+    DISPLAY_DISABLE(RscDisplayCurator);
+    DISPLAY_DISABLE(RscDisplayArsenal);
+    DISPLAY_DISABLE(ace_arsenal_display);
+};
+class Extended_DisplayUnload_EventHandlers {
+    DISPLAY_RESTORE(RscDisplayCurator);
+    DISPLAY_RESTORE(RscDisplayArsenal);
+    DISPLAY_RESTORE(ace_arsenal_display);
+};

--- a/addons/nv_color_mask/fn_applyMask.sqf
+++ b/addons/nv_color_mask/fn_applyMask.sqf
@@ -1,0 +1,29 @@
+if (isNil "cnto_nv_color_mask_rgba_ratio") exitWith {};
+
+params ["_enable"];
+if (isNil "_enable") then {
+    _enable = !isNull player && currentVisionMode player == 1;
+};
+
+if (_enable) then {
+    if (!isNil "cnto_nv_color_mask_effect") then {
+        ppEffectDestroy cnto_nv_color_mask_effect;
+    };
+    /* https://community.bistudio.com/wiki/Post_process_effects */
+    private _effect = ppEffectCreate ["ColorCorrections", 2050];
+    _effect ppEffectAdjust [
+        1, 1, 0,
+        [0,0,0,0],
+        cnto_nv_color_mask_rgba_ratio,
+        [0.299, 0.587, 0.114, 0]
+    ];
+    _effect ppEffectForceInNVG true;
+    _effect ppEffectCommit 0;
+    _effect ppEffectEnable true;
+    cnto_nv_color_mask_effect = _effect;
+} else {
+    if (!isNil "cnto_nv_color_mask_effect") then {
+        ppEffectDestroy cnto_nv_color_mask_effect;
+        cnto_nv_color_mask_effect = nil;
+    };
+};

--- a/addons/nv_color_mask/fn_init.sqf
+++ b/addons/nv_color_mask/fn_init.sqf
@@ -1,0 +1,28 @@
+[
+    "cnto_nv_color_mask_rgb",
+    "COLOR",
+    ["RGB ratio", "This specifies the Red/Green/Blue proportions of the mask, which replaces the default\nACE NVG green color. The absolute slider values don't matter - only  the proportion\nof Red vs Green vs Blue, IOW all sliders on 0.2/0.2/0.2 are equivalent to 0.6/0.6/0.6.\n\nTo leave default ACE (and save an imperceivable bit of performance), set all to 0."],
+    ["CNTO Additions", "Nightvision Color Mask"],
+    [0,0,0],
+    nil,   /* isGlobal */
+    {
+        if (!hasInterface) exitWith {};
+        if (_this isEqualTo [0,0,0] && isNil "cnto_nv_color_mask_rgba_ratio") exitWith {};
+        /* add PFH-based EH only if mask is in use, limit overhead */
+        if (isNil "cnto_nv_color_mask_rgba_ratio") then {
+            call cnto_nv_color_mask_fnc_setupEH;
+        };
+        /* recalculate RGB ratio */
+        params ["_red", "_green", "_blue"];
+        private _sum = _red + _green + _blue;
+        if (_sum != 0) then {
+            /* maintain the same brightness */
+            cnto_nv_color_mask_rgba_ratio = [_red,_green,_blue] apply { 3*(_x/_sum) };
+            /* add saturation */
+            cnto_nv_color_mask_rgba_ratio pushBack 0;
+        } else {
+            /* transparent by default */
+            cnto_nv_color_mask_rgba_ratio = [0,0,0,1];
+        };
+    }
+] call CBA_settings_fnc_init;

--- a/addons/nv_color_mask/fn_setupEH.sqf
+++ b/addons/nv_color_mask/fn_setupEH.sqf
@@ -1,0 +1,9 @@
+["visionMode", {
+    params ["_unit", "_new", "_old"];
+    if (_new == 1) then {
+        [true] call cnto_nv_color_mask_fnc_applyMask;
+    } else {
+        /* 0 (normal) or 2 (thermal) */
+        [false] call cnto_nv_color_mask_fnc_applyMask;
+    };
+}] call CBA_fnc_addPlayerEventHandler;


### PR DESCRIPTION
The code is pretty self-explanatory, strongly inspired by https://github.com/freghar/arma-additions/tree/master/addons/nightvision.

You can see on https://www.youtube.com/watch?v=c03afu_MSHU how it works in practice - to ensure that the color Post Processing isn't "cheaty" by increasing NVG brightness, I take the user input only as a R/G/B ratio and then distribute a total brightness value of 3 (that would normally be r=1, g=1, b=1) across different colors, resulting in a pretty close match to the unmodified color.

This also works with ACE NVG brightness adjustment (because it's a different PP effect) and should work with various other ACE NVG settings.