### PR TITLE
add endmission_cntr for saving CNTR recordings on any mission end

### DIFF
--- a/addons/endmission_cntr/$PBOPREFIX$
+++ b/addons/endmission_cntr/$PBOPREFIX$
@@ -1,0 +1,1 @@
+cnto\additions\endmission_cntr

--- a/addons/endmission_cntr/$PREFIX$
+++ b/addons/endmission_cntr/$PREFIX$
@@ -1,0 +1,1 @@
+cnto\additions\endmission_cntr

--- a/addons/endmission_cntr/config.cpp
+++ b/addons/endmission_cntr/config.cpp
@@ -1,0 +1,24 @@
+/*
+ * wrap BIS_fnc_endMission so that it calls CNTR (Carpe Noctem Tactical Replay)
+ * function to finish and save a recording of the mission
+ */
+class CfgPatches {
+    class cnto_endmission_cntr {
+        units[] = {};
+        weapons[] = {};
+        requiredAddons[] = { "A3_Functions_F" };
+    };
+};
+
+class CfgFunctions {
+    class HSim {
+        class Misc {
+            class endMission {
+                file = "\cnto\additions\endmission_cntr\wrapper.sqf";
+            };
+            class endMission_orig {
+                file = "A3\functions_f\Misc\fn_endMission.sqf";
+            };
+        };
+    };
+};

--- a/addons/endmission_cntr/wrapper.sqf
+++ b/addons/endmission_cntr/wrapper.sqf
@@ -1,0 +1,5 @@
+if (isDedicated && !isNil "cntr_exportPath" && !isNil "cntr_fnc_export") then {
+    diag_log "endMission: Stopping CNTR recording.";
+    ["stop", cntr_exportPath] call cntr_fnc_export;
+};
+_this call BIS_fnc_endMission_orig;


### PR DESCRIPTION
This essentially wraps the vanilla `BIS_fnc_endMission` (when called directly or via `BIS_fnc_endMissionServer`) and calls `cntr_fnc_export` in exactly the same way that the custom Zeus "End Mission - Won/Lost" module from `arma-additions/ares_extras` does. If this is confirmed working and merged, I'll modify arma-additions and remove the modules, so it's not confusing for a mission maker (so the export function isn't called twice).

I've tested this on my local dedicated server and it seems to work as expected, though a real test would be on the main private server:
1. Pack the addon into a PBO
1. Put the PBO into any mod/addons folder on the server, restart the server
1. Do the same to your local arma game (not strictly necessary, but the server has an ACE3 PBO check)
1. Connect, start some mission, go into zeus
1. Use the "Scenario Flow" --> "End Scenario" module, choose Compled or Failed
1. Wait for the mission to end (a few seconds), then check whether CNTR got successfully exported on the server
1. Check server RPT log (there should be a desktop shortcut, bottom left) and search it for "CNTR", you should find:

       2021/01/28,  4:38:29 "endMission: Stopping CNTR recording."