### PR TITLE
add boxGuard to functions/loadout

### DIFF
--- a/addons/functions/config.cpp
+++ b/addons/functions/config.cpp
@@ -13,6 +13,10 @@ class CfgPatches {
 
 class CfgFunctions {
     class cnto {
+        class loadout {
+            file = "\cnto\additions\functions\loadout";
+            class boxGuard;
+        };
         class performance {
             file = "\cnto\additions\functions\performance";
             class runTest;

--- a/addons/functions/loadout/fn_boxGuard.sqf
+++ b/addons/functions/loadout/fn_boxGuard.sqf
@@ -1,0 +1,28 @@
+/*
+ * show empty inventory on _box if it is closer than _range meters to its
+ * initial placement location (as seen on mission start)
+ */
+
+params ["_box", "_range"];
+
+if (isServer) then {
+    _box setVariable ["boxguard_data", [
+        position _box, _range
+    ], true];
+};
+if (hasInterface) then {
+    _box addEventHandler ["ContainerOpened", {
+        params ["_box", "_player"];
+
+        private _data = _box getVariable "boxguard_data";
+        if (isNil "_data") exitWith {};
+        _data params ["_initpos", "_range"];
+        if (position _box distance2D _initpos > _range) exitWith {};
+
+        0 = [] spawn {
+            waitUntil { !isNull findDisplay 602 };
+            (findDisplay 602) closeDisplay 0;
+            player action ["Gear", objNull];
+        };
+    }];
+};


### PR DESCRIPTION
Since I mentioned a while ago that I'd like to remove boxGuard from arma-additions (as it's really more of a CNTO thing), I would like to add it to cnto-additions instead to preserve the functionality for CNTO.

Compositions will need a simple rename from `a3aa_fnc_boxGuard` to `cnto_fnc_boxGuard`, but otherwise the functionality is untouched.