### PR TITLE
ace_medical_tweaks: tweak unconsciousness conditions

### DIFF
--- a/addons/ace_medical_tweaks/$PBOPREFIX$
+++ b/addons/ace_medical_tweaks/$PBOPREFIX$
@@ -1,0 +1,1 @@
+cnto\additions\ace_medical_tweaks

--- a/addons/ace_medical_tweaks/$PREFIX$
+++ b/addons/ace_medical_tweaks/$PREFIX$
@@ -1,0 +1,1 @@
+cnto\additions\ace_medical_tweaks

--- a/addons/ace_medical_tweaks/config.cpp
+++ b/addons/ace_medical_tweaks/config.cpp
@@ -1,0 +1,35 @@
+/*
+ * miscellaneous ACE Medical system tweaks for CNTO
+ */
+class CfgPatches {
+    class cnto_ace_medical_tweaks {
+        units[] = {};
+        weapons[] = {};
+        requiredAddons[] = {
+            "ace_medical_status"
+        };
+    };
+};
+
+/*
+ * unconsciousness condition tweaks
+ *
+ * override ACE's hasStableVitals function:
+ * hasn't changed in a few years (and if it does, should throw up enough errors
+ * on game startup for people to notice)
+ * https://github.com/acemod/ACE3/blob/master/addons/medical_status/functions/fnc_hasStableVitals.sqf
+ */
+class CfgFunctions {
+    class ace_medical_status {
+        class misc {
+            /*
+             * surprisingly, this works as BIS_fnc_initFunctions is faster than
+             * CBA's PREP() macro, at least with debugging disabled, and manages
+             * to finalize our code, so ACE cannot override it
+             */
+            class hasStableVitals {
+                file = "\cnto\additions\ace_medical_tweaks\custom_hasStableVitals.sqf";
+            };
+        };
+    };
+};

--- a/addons/ace_medical_tweaks/custom_hasStableVitals.sqf
+++ b/addons/ace_medical_tweaks/custom_hasStableVitals.sqf
@@ -1,0 +1,19 @@
+#include "\z\ace\addons\medical_status\script_component.hpp"
+
+params ["_unit"];
+
+//if (GET_BLOOD_VOLUME(_unit) < BLOOD_VOLUME_CLASS_2_HEMORRHAGE) exitWith { false };
+if IN_CRDC_ARRST(_unit) exitWith { false };
+
+//private _cardiacOutput = [_unit] call FUNC(getCardiacOutput);
+//private _bloodLoss = GET_BLOOD_LOSS(_unit);
+//if (_bloodLoss > (BLOOD_LOSS_KNOCK_OUT_THRESHOLD * _cardiacOutput) / 2) exitWith { false };
+
+private _bloodPressure = GET_BLOOD_PRESSURE(_unit);
+_bloodPressure params ["_bloodPressureL", "_bloodPressureH"];
+if (_bloodPressureL < 50 || {_bloodPressureH < 60}) exitWith { false };
+
+private _heartRate = GET_HEART_RATE(_unit);
+if (_heartRate < 40) exitWith { false };
+
+true


### PR DESCRIPTION
Allow wakeup when lost more than "some blood", capped by "a very large amount of blood" which causes cardiac arrest and prevents wakeup anyway. Also ignore bleeding rate.

Unfortunately, copying out and modifying `hasStableVitals` was the cleanest and most reliable solution to this.

This has been tested by players and approved by SSgts. Any morphine / IV amount changes present in previous versions of this tweak were removed, so it's just unconsciousness.