### PR TITLE
a3aa_overrides: configure CNTO static AI skill

### DIFF
--- a/addons/a3aa_overrides/$PBOPREFIX$
+++ b/addons/a3aa_overrides/$PBOPREFIX$
@@ -1,0 +1,1 @@
+cnto\additions\a3aa_overrides

--- a/addons/a3aa_overrides/$PREFIX$
+++ b/addons/a3aa_overrides/$PREFIX$
@@ -1,0 +1,1 @@
+cnto\additions\a3aa_overrides

--- a/addons/a3aa_overrides/config.cpp
+++ b/addons/a3aa_overrides/config.cpp
@@ -1,0 +1,21 @@
+/*
+ * configure/override various custom features of freghar/arma-additions
+ */
+class CfgPatches {
+    class cnto_a3aa_overrides {
+        units[] = {};
+        weapons[] = {};
+        requiredAddons[] = {
+            "a3aa_ai_dynamic_skill"
+        };
+    };
+};
+
+class CfgFunctions {
+    class cnto_a3aa_overrides {
+        class all {
+            file = "\cnto\additions\a3aa_overrides";
+            class customAISkills { preInit = 1; };
+        };
+    };
+};

--- a/addons/a3aa_overrides/fn_customAISkills.sqf
+++ b/addons/a3aa_overrides/fn_customAISkills.sqf
@@ -1,0 +1,23 @@
+/*
+ * configure AI / Dynamic skill custom static AI skill equivalent to
+ * - default vanilla CfgAISkill
+ * - precisionAI=0.5 / skillAI=1
+ * - individual unit skill = 0.5 (default)
+ *
+ * pulled directly from the game via skillFinal
+ */
+
+a3aa_ai_dynamic_skill_custom = {
+    [
+        0.4625,  // aimingAccuracy
+        0.4625,  // aimingShake
+        0.875,   // aimingSpeed
+        0.75,    // endurance
+        0.75,    // spotDistance
+        0.75,    // spotTime
+        0.75,    // courage
+        0.75,    // reloadSpeed
+        0.75,    // commanding
+        0.75     // general
+    ];
+};


### PR DESCRIPTION
Right now, `@freghar_a3aa` in the CNTO modset doesn't include the `ai` component at all. I would like to change that for a few reasons:
* There are additional features we might want to enable
   * Preventing AI from dismounting a vehicle with damaged wheels (unless LAMBS overrides that behavior)
   * Boosting game (client) performance by disabling visibility raycasts of remote AI units (that are on HCs)
* The full 0-1 range of AI skill is unlocked thanks to `CfgAISkill` and `skillAI=1` / `precisionAI=1`
   * This allows selective overrides by a MM, ie. to make ZSU an actual threat, a strategic marksman reasonably accurate, etc.
* We could basically use off-the-shelf `arma-additions` without any CNTO specific PBO repacking/removal
* We could experiment with `dynamic_skill` and how different skill values interact with LAMBS on miniops

This pull request adds a configuration for `dynamic_skill` that mimics the current static skill setting. This means there will be no change in AI behavior compared to how CNTO has it now. The values seem weird, but they are just `0.5` modified by `skillAI`/`precisionAI` modified by the vanilla `CfgAISkills`, whereas (with the `ai` component of `@freghar_a3aa`), these abstractions are stripped away, so the actual "final" values are used.

I chose the addon name (`a3aa_overrides`) generic enough as I think we could use it for https://github.com/CntoDev/cnto-additions/issues/28 and other cases where customization is supported in a3aa. I'd like to avoid having tons of cnto-additions directories.

PS: Do not merge this until the next https://steamcommunity.com/sharedfiles/filedetails/changelog/1470700937 release (in April).