### PR TITLE
validate_mission: add CNTO specifics to A3AA's validate mission

### DIFF
--- a/addons/validate_mission/$PBOPREFIX$
+++ b/addons/validate_mission/$PBOPREFIX$
@@ -1,0 +1,1 @@
+cnto\additions\validate_mission

--- a/addons/validate_mission/$PREFIX$
+++ b/addons/validate_mission/$PREFIX$
@@ -1,0 +1,1 @@
+cnto\additions\validate_mission

--- a/addons/validate_mission/config.cpp
+++ b/addons/validate_mission/config.cpp
@@ -1,0 +1,28 @@
+/*
+ * add additional checks to A3AA's validate mission system
+ */
+class CfgPatches {
+    class cnto_validate_mission {
+        units[] = {};
+        weapons[] = {};
+        requiredAddons[] = {
+            "cba_xeh",
+            "a3aa_ee_validate_mission"
+        };
+    };
+};
+
+class CfgFunctions {
+    class cnto_validate_mission {
+        class all {
+            file = "\cnto\additions\validate_mission";
+            class run;
+        };
+    };
+};
+
+class Extended_PreInit_EventHandlers {
+    class cnto_validate_mission {
+        init = "cnto_validate_mission_fnc_run call a3aa_ee_validate_mission_fnc_register";
+    };
+};

--- a/addons/validate_mission/fn_run.sqf
+++ b/addons/validate_mission/fn_run.sqf
@@ -1,0 +1,143 @@
+/*
+ * See https://github.com/freghar/arma-additions/blob/master/addons/editor_extensions/validate_mission/README.md
+ */
+
+private _check_game_type = {
+    private _type = "Multiplayer" get3DENMissionAttribute "GameType";
+    if (_type in ["Coop","DM"]) then {
+        ["Game Type", true]
+    } else {
+        ["Game Type", false, [], [
+            format ["Unexpected game type %1.", _type],
+            "This may be okay for a custom mission, but none of the default modules",
+            "use this type. If you're making a normal mission, check that a module",
+            "composition was placed."
+        ]]
+    };
+};
+
+private _check_respawn_type = {
+    private _gametype = "Multiplayer" get3DENMissionAttribute "GameType";
+    private _respawn = "Multiplayer" get3DENMissionAttribute "Respawn";
+    if (!(_gametype in ["Coop","DM"])) exitWith {
+        ["Respawn Type", true]  /* unknown, pass */
+    };
+    /* 3 = custom position, 1 = spectator */
+    if (
+        (_gametype == "Coop" && _respawn in [3,1]) ||
+        (_gametype == "DM" && _respawn == 1)
+        ) then {
+        ["Respawn Type", true]
+    } else {
+        ["Respawn Type", false, [], [
+            "Invalid respawn settings for Coop/PvP.",
+            "Make sure the correct module composition was placed and respawn settings",
+            "were not edited."
+        ]]
+    };
+};
+
+private _check_respawn_marker_invis = {
+    private _markers = all3DENEntities select 5;
+    private _respawns = _markers select { _x select [0,7] == "respawn" };
+    private _failed = [];
+    {
+        private _alpha = _x get3DENAttribute "alpha" select 0;
+        if (_alpha > 0) then {
+            _failed pushBack _x;
+        };
+    } forEach _respawns;
+
+    if (_failed isEqualTo []) then {
+        ["Respawn Markers Invisible", true]
+    } else {
+        ["Respawn Markers Invisible", false, _failed, [
+            "Some respawn markers are visible.",
+            "Double click them in the left panel (or on the map screen) and set their",
+            "'Alpha' value all the way to 0%."
+        ]]
+    };
+};
+
+private _check_respawn_marker_proximity = {
+    private _markers = all3DENEntities select 5;
+    private _failed = [];
+    private _maxdist = 100;
+    private _playable = playableUnits + [player] - [objNull];
+    private _respawns = _markers select { _x select [0,7] == "respawn" };
+    {
+        private _marker = _x;
+        private _marker_pos = _marker get3DENAttribute "position" select 0 select [0,2];
+        /* watch out for respawn_0, respawn_1, respawn_west_1, etc. */
+        private _split = (_marker splitString "_") + [""];
+        private _side = switch (_split select 1) do {
+            case "west": { west };
+            case "east": { east };
+            case "guerrila";
+            case "guerrilla";
+            case "guerilla";
+            case "guerila": { resistance };
+            default { sideUnknown };
+        };
+        private _playable_side = _playable;
+        if (_side != sideUnknown) then {
+            /* per-side respawn */
+            _playable_side = _playable select { side _x == _side };
+        };
+        private _nearest = 100000;
+        {
+            _nearest = _nearest min (_x distance _marker_pos);
+        } forEach _playable_side;
+        if (_nearest > _maxdist) then {
+            _failed pushBack _marker;
+        };
+    } forEach _respawns;
+
+    if (_failed isEqualTo []) then {
+        ["Respawn Markers Proximity", true]
+    } else {
+        ["Respawn Markers Proximity", false, _failed, [
+            format ["One or more respawn markers is >%1m away from nearest playable unit.", _maxdist],
+            "This may be fine if you want players respawning in a location different",
+            "from their starting one, but maybe you also accidentally moved playable",
+            "units without moving their respawn marker."
+        ]]
+    };
+};
+
+private _check_mission_info = {
+    private _title = "Scenario" get3DENMissionAttribute "IntelBriefingName";
+    private _picture = "Scenario" get3DENMissionAttribute "OverviewPicture";
+    private _text = "Scenario" get3DENMissionAttribute "OverviewText";
+    private _msg = [];
+    if (_title == "") then { _msg pushBack "Mission Title is empty." };
+    if (_picture == "") then { _msg pushBack "Mission Overview Picture is empty." };
+    if (_text == "") then { _msg pushBack "Mission Overview Text is empty." };
+    if (_title != "") then {
+        ["Mission Info", true, [], _msg]
+    } else {
+        ["Mission Info", false, [], _msg + [
+            "Fill in at least the mission Title in Attributes -> General."
+        ]]
+    };
+};
+
+private _check_cba_settings = {
+    private _changed = (allVariables CBA_settings_mission) select {
+        ([_x] call CBA_settings_fnc_priority) isEqualTo "mission";
+    };
+    private _strings = _changed apply {
+        format ["%1 = %2;", _x, [_x, "mission"] call CBA_settings_fnc_get];
+    };
+    ["Changed CBA Settings", true, [], _strings];
+};
+
+
+[
+    [] call _check_game_type,
+    [] call _check_respawn_type,
+    [] call _check_respawn_marker_invis,
+    [] call _check_respawn_marker_proximity,
+    [] call _check_mission_info,
+    [] call _check_cba_settings
+];

--- a/addons/validate_mission/fn_run.sqf
+++ b/addons/validate_mission/fn_run.sqf
@@ -5,9 +5,9 @@
 private _check_game_type = {
     private _type = "Multiplayer" get3DENMissionAttribute "GameType";
     if (_type in ["Coop","DM"]) then {
-        ["Game Type", true];
+        ["Game type", true];
     } else {
-        ["Game Type", false, [], [
+        ["Game type", false, [], [
             format ["Unexpected game type %1.", _type],
             "This may be okay for a custom mission, but none of the default modules",
             "use this type. If you're making a normal mission, check that a module",
@@ -20,16 +20,16 @@ private _check_respawn_type = {
     private _gametype = "Multiplayer" get3DENMissionAttribute "GameType";
     private _respawn = "Multiplayer" get3DENMissionAttribute "Respawn";
     if (!(_gametype in ["Coop","DM"])) exitWith {
-        ["Respawn Type", true]  /* unknown, pass */
+        ["Respawn type", true]  /* unknown, pass */
     };
     /* 3 = custom position, 1 = spectator */
     if (
         (_gametype == "Coop" && _respawn in [3,1]) ||
         (_gametype == "DM" && _respawn == 1)
         ) then {
-        ["Respawn Type", true];
+        ["Respawn type", true];
     } else {
-        ["Respawn Type", false, [], [
+        ["Respawn type", false, [], [
             "Invalid respawn settings for Coop/PvP.",
             "Make sure the correct module composition was placed and respawn settings",
             "were not edited."
@@ -43,9 +43,9 @@ private _check_respawn_marker_invis = {
         _x select [0,7] == "respawn" && _alpha > 0;
     };
     if (_failed isEqualTo []) then {
-        ["Respawn Markers Invisible", true];
+        ["Respawn markers invisible", true];
     } else {
-        ["Respawn Markers Invisible", false, _failed, [
+        ["Respawn markers invisible", false, _failed, [
             "Some respawn markers are visible.",
             "Double click them in the left panel (or on the map screen) and set their",
             "'Alpha' value all the way to 0%."
@@ -68,7 +68,7 @@ private _check_respawn_marker_proximity = {
         _found == -1;
     };
     if (_failed isEqualTo []) then {
-        ["Respawn Markers Proximity", true];
+        ["Respawn markers proximity", true];
     } else {
         private _msg = [
             format ["One or more respawn markers is >%1m away from nearest playable unit.", _maxdist],
@@ -92,17 +92,40 @@ private _check_respawn_marker_proximity = {
                     "which is probably not intentional (JIPs joining on a place different",
                     "from where players respawn). Move it closer to a respawn marker."
                 ];
-                ["Respawn Markers Proximity", false, _failed, _msg];
+                ["Respawn markers proximity", false, _failed, _msg];
             } else {
-                ["Respawn Markers Proximity", true];
+                ["Respawn markers proximity", true];
             };
         } else {
             _msg append [
                 "If the starting position is vastly different from the respawn location,",
                 "consider using the 'Teleport on JIP' module."
             ];
-            ["Respawn Markers Proximity", false, _failed, _msg];
+            ["Respawn markers proximity", false, _failed, _msg];
         };
+    };
+};
+
+private _check_respawn_marker_count = {
+    private _gametype = "Multiplayer" get3DENMissionAttribute "GameType";
+    if (_gametype != "Coop") exitWith {
+        ["Respawn marker count", true];
+    };
+    private _count = {
+        _x select [0,7] == "respawn";
+    } count (all3DENEntities select 5);
+    if (_count <= 1) then {
+        ["Respawn marker count", true];
+    } else {
+        ["Respawn marker count", false, [], [
+            format ["Found >1 (%1) respawn markers.", _count],
+            "Using multiple respawn markers for Coop results in players respawning",
+            "on randomly chosen respawn markers. This is a very rare use case.",
+            "It's more likely that you deleted a player faction composition in 3D",
+            "and re-placed it, leaving old map markers behind.",
+            "Either delete those markers from the left panel (or map view) or simply",
+            "delete the entire placed composition in map view + re-place it."
+        ]];
     };
 };
 
@@ -115,9 +138,9 @@ private _check_mission_info = {
     if (_picture == "") then { _msg pushBack "Mission Overview Picture is empty." };
     if (_text == "") then { _msg pushBack "Mission Overview Text is empty." };
     if (_title != "") then {
-        ["Mission Info", true, [], _msg];
+        ["Mission info", true, [], _msg];
     } else {
-        ["Mission Info", false, [], _msg + [
+        ["Mission info", false, [], _msg + [
             "Fill in at least the mission Title in Attributes -> General."
         ]];
     };
@@ -130,7 +153,7 @@ private _check_cba_settings = {
     private _strings = _changed apply {
         format ["%1 = %2;", _x, [_x, "mission"] call CBA_settings_fnc_get];
     };
-    ["Changed CBA Settings", true, [], _strings];
+    ["Changed CBA settings", true, [], _strings];
 };
 
 
@@ -139,6 +162,7 @@ private _check_cba_settings = {
     [] call _check_respawn_type,
     [] call _check_respawn_marker_invis,
     [] call _check_respawn_marker_proximity,
+    [] call _check_respawn_marker_count,
     [] call _check_mission_info,
     [] call _check_cba_settings
 ];

--- a/addons/validate_mission/fn_run.sqf
+++ b/addons/validate_mission/fn_run.sqf
@@ -5,14 +5,14 @@
 private _check_game_type = {
     private _type = "Multiplayer" get3DENMissionAttribute "GameType";
     if (_type in ["Coop","DM"]) then {
-        ["Game Type", true]
+        ["Game Type", true];
     } else {
         ["Game Type", false, [], [
             format ["Unexpected game type %1.", _type],
             "This may be okay for a custom mission, but none of the default modules",
             "use this type. If you're making a normal mission, check that a module",
             "composition was placed."
-        ]]
+        ]];
     };
 };
 
@@ -27,81 +27,82 @@ private _check_respawn_type = {
         (_gametype == "Coop" && _respawn in [3,1]) ||
         (_gametype == "DM" && _respawn == 1)
         ) then {
-        ["Respawn Type", true]
+        ["Respawn Type", true];
     } else {
         ["Respawn Type", false, [], [
             "Invalid respawn settings for Coop/PvP.",
             "Make sure the correct module composition was placed and respawn settings",
             "were not edited."
-        ]]
+        ]];
     };
 };
 
 private _check_respawn_marker_invis = {
-    private _markers = all3DENEntities select 5;
-    private _respawns = _markers select { _x select [0,7] == "respawn" };
-    private _failed = [];
-    {
+    private _failed = (all3DENEntities select 5) select {
         private _alpha = _x get3DENAttribute "alpha" select 0;
-        if (_alpha > 0) then {
-            _failed pushBack _x;
-        };
-    } forEach _respawns;
-
+        _x select [0,7] == "respawn" && _alpha > 0;
+    };
     if (_failed isEqualTo []) then {
-        ["Respawn Markers Invisible", true]
+        ["Respawn Markers Invisible", true];
     } else {
         ["Respawn Markers Invisible", false, _failed, [
             "Some respawn markers are visible.",
             "Double click them in the left panel (or on the map screen) and set their",
             "'Alpha' value all the way to 0%."
-        ]]
+        ]];
     };
 };
 
 private _check_respawn_marker_proximity = {
-    private _markers = all3DENEntities select 5;
-    private _failed = [];
     private _maxdist = 100;
     private _playable = playableUnits + [player] - [objNull];
-    private _respawns = _markers select { _x select [0,7] == "respawn" };
-    {
-        private _marker = _x;
-        private _marker_pos = _marker get3DENAttribute "position" select 0 select [0,2];
-        /* watch out for respawn_0, respawn_1, respawn_west_1, etc. */
-        private _split = (_marker splitString "_") + [""];
-        private _side = switch (_split select 1) do {
-            case "west": { west };
-            case "east": { east };
-            case "guerrila";
-            case "guerrilla";
-            case "guerilla";
-            case "guerila": { resistance };
-            default { sideUnknown };
+    private _respawns = (all3DENEntities select 5) select {
+        _x select [0,7] == "respawn";
+    };
+    private _failed = _respawns select {
+        private _marker_pos = _x get3DENAttribute "position" select 0 select [0,2];
+        private _found = _playable findIf {
+            private _pos2d = position _x select [0,2];
+            _pos2d distance _marker_pos < _maxdist;
         };
-        private _playable_side = _playable;
-        if (_side != sideUnknown) then {
-            /* per-side respawn */
-            _playable_side = _playable select { side _x == _side };
-        };
-        private _nearest = 100000;
-        {
-            _nearest = _nearest min (_x distance _marker_pos);
-        } forEach _playable_side;
-        if (_nearest > _maxdist) then {
-            _failed pushBack _marker;
-        };
-    } forEach _respawns;
-
+        _found == -1;
+    };
     if (_failed isEqualTo []) then {
-        ["Respawn Markers Proximity", true]
+        ["Respawn Markers Proximity", true];
     } else {
-        ["Respawn Markers Proximity", false, _failed, [
+        private _msg = [
             format ["One or more respawn markers is >%1m away from nearest playable unit.", _maxdist],
-            "This may be fine if you want players respawning in a location different",
-            "from their starting one, but maybe you also accidentally moved playable",
-            "units without moving their respawn marker."
-        ]]
+            "Perhaps you accidentally moved playable units without moving their",
+            "respawn marker?"
+        ];
+        private _modules = all3DENEntities select 3;
+        private _found = _modules findIf { _x isKindOf "a3aa_ee_teleport_on_jip" };
+        if (_found != -1) then {
+            private _tel_on_jip = _modules select _found;
+            private _pos2d = position _tel_on_jip select [0,2];
+            private _closest_respawn = selectMin (
+                _respawns apply {
+                    private _marker_pos = _x get3DENAttribute "position" select 0 select [0,2];
+                    _pos2d distance _marker_pos;
+                }
+            );
+            if (_closest_respawn > _maxdist) then {
+                _msg append [
+                    format ["The 'Teleport on JIP' module is also >%1m away from nearest respawn", _maxdist],
+                    "which is probably not intentional (JIPs joining on a place different",
+                    "from where players respawn). Move it closer to a respawn marker."
+                ];
+                ["Respawn Markers Proximity", false, _failed, _msg];
+            } else {
+                ["Respawn Markers Proximity", true];
+            };
+        } else {
+            _msg append [
+                "If the starting position is vastly different from the respawn location,",
+                "consider using the 'Teleport on JIP' module."
+            ];
+            ["Respawn Markers Proximity", false, _failed, _msg];
+        };
     };
 };
 
@@ -114,11 +115,11 @@ private _check_mission_info = {
     if (_picture == "") then { _msg pushBack "Mission Overview Picture is empty." };
     if (_text == "") then { _msg pushBack "Mission Overview Text is empty." };
     if (_title != "") then {
-        ["Mission Info", true, [], _msg]
+        ["Mission Info", true, [], _msg];
     } else {
         ["Mission Info", false, [], _msg + [
             "Fill in at least the mission Title in Attributes -> General."
-        ]]
+        ]];
     };
 };
 


### PR DESCRIPTION
This implements some of the checks described in https://github.com/CntoDev/cnto-additions/issues/28, see an example output (pieced together from failing checks), the first 4 of which come from A3AA directly (not implemented here):
```
Mission validation report
-------------------------
Overloaded units: PASS
Unique ACRE _ID_ radios: PASS
Playable unit ordering: PASS
Persistent callsigns: PASS
Game Type: FAIL

    Unexpected game type CTI.
    This may be okay for a custom mission, but none of the default modules
    use this type. If you're making a normal mission, check that a module
    composition was placed.

Respawn Type: FAIL

    Invalid respawn settings for Coop/PvP.
    Make sure the correct module composition was placed and respawn settings
    were not edited.

Respawn Markers Invisible: FAIL
 - marker:'respawn_west'

    Some respawn markers are visible.
    Double click them in the left panel (or on the map screen) and set their
    'Alpha' value all the way to 0%.

Respawn Markers Proximity: FAIL
 - marker:'respawn_west'

    One or more respawn markers is >100m away from nearest playable unit.
    This may be fine if you want players respawning in a location different
    from their starting one, but maybe you also accidentally moved playable
    units without moving their respawn marker.

Mission Info: FAIL

    Mission Title is empty.
    Mission Overview Picture is empty.
    Mission Overview Text is empty.
    Fill in at least the mission Title in Attributes -> General.

Changed CBA Settings: PASS

    ace_medical_statemachine_fatalinjuriesplayer = 0;
    ace_captives_allowhandcuffownside = false;
```

I'm not sure if the all-in-one-file approach is best - having checks in separate files would be cleaner, but it would also reduce copy-pasta-bility of some common code (you'd have to open / scour many files).

The "Mission Info" fails only if Title is empty, it will still report empty picture/text, but with a PASS as those are I think optional.

Comments?


PS: Note that this needs new A3AA (arma-additions) from Steam, currently (2021-04-22) not in the CNTO modset.