### PR TITLE
5.45 CAR-95 support

### DIFF
--- a/addons/545_CAR95/config.cpp
+++ b/addons/545_CAR95/config.cpp
@@ -1,0 +1,23 @@
+class CfgPatches {
+    class cnto_545_CAR95 {
+        units[] = {};
+        weapons[] = {"Rifle_Base_F", "arifle_CTARS_base_F", "arifle_CTAR_base_F"};
+        requiredAddons[] = {
+            "A3_Weapons_F_Exp_Rifles_CTARS",
+            "rhs_c_weapons",
+            "cba_jam"
+        };
+    };
+};
+
+class CfgWeapons {
+    class Rifle_Base_F;
+    class arifle_CTARS_base_F: Rifle_Base_F
+    {
+        magazineWell[] = {"CTAR_580x42","CTAR_580x42_Large","CBA_580x42_TYPE95","CBA_580x42_TYPE95_XL", "AK_545x39","CBA_545x39_AK","CBA_545x39_RPK"};
+    };
+    class arifle_CTAR_base_F: Rifle_Base_F
+    {
+        magazineWell[] = {"CTAR_580x42","CTAR_580x42_Large","CBA_580x42_TYPE95","CBA_580x42_TYPE95_XL", "AK_545x39","CBA_545x39_AK","CBA_545x39_RPK"};
+    };
+};

--- a/addons/magazine_compats/config.cpp
+++ b/addons/magazine_compats/config.cpp
@@ -1,24 +1,35 @@
 class CfgPatches {
     class cnto_magazine_compats {
         units[] = {};
-        weapons[] = {"Rifle_Base_F", "arifle_CTARS_base_F", "arifle_CTAR_base_F"};
+        weapons[] = {};
         requiredAddons[] = {
-            "A3_Weapons_F_Exp_Rifles_CTARS",
-            "rhs_c_weapons",
-            "cba_jam"
+            "A3_Weapons_F_Exp_Rifles_CTARS"
+            // "rhs_c_weapons",
+            // "cba_jam"
         };
     };
 };
 
-class CfgWeapons {
+class CfgWeapons 
+{
     class Rifle_Base_F;
     // Make CAR-95 able to use 5.45mm ammo.
     class arifle_CTARS_base_F: Rifle_Base_F
     {
-        magazineWell[] = {"CTAR_580x42","CTAR_580x42_Large","CBA_580x42_TYPE95","CBA_580x42_TYPE95_XL", "AK_545x39","CBA_545x39_AK","CBA_545x39_RPK"};
+        magazineWell[] += {
+            // RHS AK_545x39 Magazine well from "rhs_c_weapons"
+            "AK_545x39", 
+            // CBA Magazine wells from addon "cba_jam"
+            "CBA_545x39_AK", "CBA_545x39_RPK"
+        };
     };
     class arifle_CTAR_base_F: Rifle_Base_F
     {
-        magazineWell[] = {"CTAR_580x42","CTAR_580x42_Large","CBA_580x42_TYPE95","CBA_580x42_TYPE95_XL", "AK_545x39","CBA_545x39_AK","CBA_545x39_RPK"};
+        magazineWell[] += {
+            // RHS AK_545x39 Magazine well from "rhs_c_weapons"
+            "AK_545x39", 
+            // CBA Magazine wells from addon "cba_jam"
+            "CBA_545x39_AK", "CBA_545x39_RPK"
+        };
     };
 };

--- a/addons/magazine_compats/config.cpp
+++ b/addons/magazine_compats/config.cpp
@@ -1,5 +1,5 @@
 class CfgPatches {
-    class cnto_545_CAR95 {
+    class cnto_magazine_compats {
         units[] = {};
         weapons[] = {"Rifle_Base_F", "arifle_CTARS_base_F", "arifle_CTAR_base_F"};
         requiredAddons[] = {
@@ -12,6 +12,7 @@ class CfgPatches {
 
 class CfgWeapons {
     class Rifle_Base_F;
+    // Make CAR-95 able to use 5.45mm ammo.
     class arifle_CTARS_base_F: Rifle_Base_F
     {
         magazineWell[] = {"CTAR_580x42","CTAR_580x42_Large","CBA_580x42_TYPE95","CBA_580x42_TYPE95_XL", "AK_545x39","CBA_545x39_AK","CBA_545x39_RPK"};


### PR DESCRIPTION
Now that we're allowing APEX stuff, I'd like to use this weapon more as it's the only chinese/east asian weapon in the entire game.

_however_, alternative weapons must be provided for non-dlc people, The problem is it uses custom 5.8mm ammo so anyone with an alternative weapon needs alternative ammo.

This just lets the CAR95 use 5.45mm ammo so it's all consistent.