### PR TITLE
add safe_ied that destroys wheels/windows

### DIFF
--- a/addons/safe_ied/$PBOPREFIX$
+++ b/addons/safe_ied/$PBOPREFIX$
@@ -1,0 +1,1 @@
+cnto\additions\safe_ied

--- a/addons/safe_ied/$PREFIX$
+++ b/addons/safe_ied/$PREFIX$
@@ -1,0 +1,1 @@
+cnto\additions\safe_ied

--- a/addons/safe_ied/config.cpp
+++ b/addons/safe_ied/config.cpp
@@ -1,0 +1,120 @@
+/*
+ * add a "safe IED" object that does very little actual engine damage
+ * (barely enough to kill a soldier), but runs additional scripting
+ *  to destroy the wheels of a nearest vehicle that presumably triggered
+ *  the mine)
+ *
+ * the intended use case is to reliably paralyze a player convoy (or any
+ * vehicle) without actually destroying the vehicle
+ */
+class CfgPatches {
+    class cnto_safe_ied {
+        units[] = {
+            "cnto_safe_ied",
+            "cnto_safe_ied_curator_module"
+//            "cnto_safe_ied_invis",
+//            "cnto_safe_ied_curator_module_invis"
+        };
+        weapons[] = {};
+        magazines[] = {};
+        requiredAddons[] = {
+            "A3_Weapons_F_Explosives"
+        };
+    };
+};
+
+class CfgMineTriggers {
+    class Default;
+    class cnto_safe_ied_trigger : Default {
+        mineTriggerType = "radius";
+        mineTriggerRange = 1;
+        mineTriggerMass = 200;
+        mineDelay = 0;
+        mineMagnetic = 1;
+    };
+};
+
+class CfgMagazines {
+    class ATMine_Range_Mag;
+    class cnto_safe_ied_mag : ATMine_Range_Mag {
+        displayName = "CNTO Safe IED";
+        ammo = "cnto_safe_ied_ammo";
+    };
+/*
+    class cnto_safe_ied_invis_mag : cnto_safe_ied_mag {
+        displayName = "CNTO Safe IED (Invisible)";
+        ammo = "cnto_safe_ied_invis_ammo";
+        // have the mag visible, so players can see disarmed mines
+        //model = "\A3\weapons_f\empty.p3d";
+    };
+*/
+};
+
+class CfgAmmo {
+    class ATMine_Range_Ammo;
+    class cnto_safe_ied_ammo : ATMine_Range_Ammo {
+        defaultMagazine = "cnto_safe_ied_mag";
+        hit = 1;
+        indirectHit = 4;
+        indirectHitRange = 8;
+        //mineInconspicuousness = 40;
+        mineTrigger = "cnto_safe_ied_trigger";
+        explosionEffects = "DirectionalMineExplosionBig";
+        craterEffects = "";
+        craterShape = "\A3\weapons_f\empty.p3d";
+        SoundSetExplosion[] = {
+            "M6slamMine_Exp_SoundSet",
+            "M6slamMine_Tail_SoundSet",
+            "Explosion_Debris_SoundSet"
+        };
+        class Eventhandlers {
+            class cnto_safe_ied_explode {
+                AmmoHit = "_this call cnto_safe_ied_fnc_pickVehicle";
+            };
+        };
+    };
+
+/*
+    class cnto_safe_ied_invis_ammo : cnto_safe_ied_ammo {
+        model = "\A3\weapons_f\empty.p3d";
+    };
+*/
+};
+
+class CfgFunctions {
+    class cnto_safe_ied {
+        class all {
+            file = "\cnto\additions\safe_ied";
+            class pickVehicle;
+            class explode;
+        };
+    };
+};
+
+class CfgVehicles {
+    class ATMine;
+    class cnto_safe_ied : ATMine {
+        displayName = "CNTO Safe IED";
+        ammo = "cnto_safe_ied_ammo";
+        mapSize = 0;
+        model = "\A3\Weapons_f\Explosives\mine_at";
+    };
+    class ModuleMine_ATMine_F;
+    class cnto_safe_ied_curator_module : ModuleMine_ATMine_F {
+        displayName = "CNTO Safe IED";
+        explosive = "cnto_safe_ied_ammo";
+        icon = "iconExplosiveAT";
+    };
+
+/*
+    class cnto_safe_ied_invis : cnto_safe_ied {
+        displayName = "CNTO Safe IED (Invisible)";
+        ammo = "cnto_safe_ied_invis_ammo";
+        model = "\A3\weapons_f\empty.p3d";
+    };
+    class cnto_safe_ied_curator_module_invis : cnto_safe_ied_curator_module {
+        displayName = "CNTO Safe IED (Invisible)";
+        explosive = "cnto_safe_ied_invis_ammo";
+    };
+*/
+};

--- a/addons/safe_ied/fn_explode.sqf
+++ b/addons/safe_ied/fn_explode.sqf
@@ -1,0 +1,27 @@
+(getAllHitpointsDamage _this) params ["_hpnames", "_selections", "_damages"];
+
+// damage its wheels + glasses
+{
+    switch true do {
+        // always kill front wheels
+        case (_x regexMatch "hit[lr]fwheel"): {
+            _this setHitPointDamage [_x, 1];
+        };
+        // 50/50 on other wheels
+        case (_x find "wheel" != -1): {
+            private _dmg = _damages select _forEachIndex;
+            _this setHitPointDamage [_x, (random 1 + 0.5 + _dmg) min 1];
+        };
+        // damage and maybe fully destroy some windows
+        case (_x find "glass" != -1): {
+            private _dmg = _damages select _forEachIndex;
+            _this setHitPointDamage [_x, (random 1 + 0.5 + _dmg) min 1];
+        };
+        // add a bit of damage to the engine - don't add more than 0.5
+        // as hitengine has a wider range of perceivable damage
+        case (_x == "hitengine"): {
+            private _dmg = _damages select _forEachIndex;
+            _this setHitPointDamage [_x, (random 0.5 + _dmg) min 1];
+        };
+    };
+} forEach _hpnames;

--- a/addons/safe_ied/fn_pickVehicle.sqf
+++ b/addons/safe_ied/fn_pickVehicle.sqf
@@ -1,0 +1,21 @@
+/*
+ * don't run this everywhere - while setHitPointDamage is AL,
+ * network desync might result in more than 1 vehicle being picked
+ * as "nearest" and 2 or more explosions could happen from 1 mine
+ *
+ * therefore do this safely, pick a nearest vic on server only and
+ * then remoteExec it everywhere (to safeguard against locality transfer
+ * mid-remoteExec)
+ */
+
+if (!isServer) exitWith {};
+
+params ["_mine", "", "", "_pos"];
+
+// find a nearby vehicle
+private _objs = nearestObjects [_pos, ["Car", "Tank", "Motorcycle"], 5, true];
+if (_objs isEqualTo []) exitWith {};
+private _veh = _objs select 0;
+if (!(_veh isKindOf "Car")) exitWith {};
+
+_veh remoteExec ["cnto_safe_ied_fnc_explode"];


### PR DESCRIPTION
Add a "safe IED" object that does very little actual vehicle damage (barely enough to kill/damage a soldier), but runs additional scripting to destroy the wheels of a nearest vehicle that presumably triggered the mine.

The intended use case is to reliably paralyze a player convoy (or any vehicle) without actually destroying the vehicle or injuring the crew.

There is some medium engine damage done each time a vehicle hits this IED (so a wheel change isn't a guaranteed fix), but gun/turret/body is never damaged, so the vehicle should never explode (unless we enable ACE Advanced Vehicle Damage).

The IED itself looks like an AT mine, but that's only because the AT mine model can be hidden really well on a road, so it doesn't have to be "cheaty" (invisible) for players to accidentally hit it, but still gives them a chance to spot it.

The mine does not have anything else in common with AT mines - a custom config was created that:
* Triggers using a magnetic sensor (any vehicle, even light ones, but not infantry).
* Makes the explosion and sound look and sound like an M6 "Slam" mine, a sharp dull thud, not a fireball of an explosion.
* Has 100% chance to destroy front wheels, some lesser chance to destroy rear wheels and glass windows, and damage the engine.

For the record, the mine can be disarmed using ACE interaction as usual, and even re-planted by the player, though that makes it more visible due to ACE mine positioning bugs.