### PR TITLE
add ace_no_headless, hiding non-functional Eden checkboxes

### DIFF
--- a/addons/ace_no_headless/$PBOPREFIX$
+++ b/addons/ace_no_headless/$PBOPREFIX$
@@ -1,0 +1,1 @@
+cnto\additions\ace_no_headless

--- a/addons/ace_no_headless/$PREFIX$
+++ b/addons/ace_no_headless/$PREFIX$
@@ -1,0 +1,1 @@
+cnto\additions\ace_no_headless

--- a/addons/ace_no_headless/config.cpp
+++ b/addons/ace_no_headless/config.cpp
@@ -1,0 +1,35 @@
+/*
+ * delete ACE Headless checkboxes in 3DEN, to prevent confusion
+ * (they don't work, CNTO doesn't use ACE Headless)
+ */
+
+class CfgPatches {
+    class cnto_ace_no_headless {
+        units[] = {};
+        weapons[] = {};
+        requiredAddons[] = {
+            "ace_headless"
+        };
+    };
+};
+
+class Cfg3DEN {
+    class Object {
+        class AttributeCategories {
+            class ace_attributes {
+                class Attributes {
+                    delete acex_headless_blacklist;
+                };
+            };
+        };
+    };
+    class Group {
+        class AttributeCategories {
+            class ace_attributes {
+                class Attributes {
+                    delete acex_headless_blacklist;
+                };
+            };
+        };
+    };
+};


### PR DESCRIPTION
Just to help mission makers avoid the non-working checkboxes.

The one that works is

![20220812165528_1](https://user-images.githubusercontent.com/23681/184414538-67ff28c3-2b84-4e90-963e-fd1bd7dbd801.jpg)

